### PR TITLE
Create blueberry language model and tokenizer

### DIFF
--- a/docs/source/en/model_doc/blueberry.md
+++ b/docs/source/en/model_doc/blueberry.md
@@ -1,0 +1,50 @@
+## Blueberry
+
+Author: Dustin Loring — Website: `https://dustinwloring1988.github.io`
+
+Copyright © September 15 2025
+
+### Overview
+
+Blueberry is a small, non-MoE, decoder-only Transformer for text generation. It features a hybrid attention architecture that alternates between sliding-window attention with Rotary Position Embeddings (RoPE) and full-span attention without positional embeddings (NoPE). The RoPE implementation supports YaRN scaling for extended context handling.
+
+- Hidden size: configurable (default 768)
+- Layers: configurable (default 12)
+- Heads: configurable (default 12)
+- Vocabulary: 100K (GPT-2 BPE-compatible files `vocab.json`, `merges.txt`)
+- Attention: Alternating sliding-window RoPE and full NoPE via `layer_types`
+- Tokenizer: GPT-2-like with Harmony Chat Format template
+
+### Model Architecture
+
+- Hybrid NoPE/RoPE: Layers marked as `sliding_attention` use RoPE with a sliding context window, while `full_attention` layers use full attention without positional encoding. This mirrors patterns used by models like smollm3.
+- RoPE with YaRN: The RoPE mechanism integrates YaRN scaling parameters through `config.rope_scaling`, enabling context extension. See `transformers.modeling_rope_utils` for details.
+
+### Tokenizer and Harmony Chat Format
+
+The `BlueberryTokenizer` and `BlueberryTokenizerFast` are GPT-2 style tokenizers (byte-level BPE). They register Harmony special tokens and expose a Jinja2 chat template under `tokenizer.chat_template` that formats conversations across roles and channels:
+
+```jinja
+{% for message in messages %}
+    {% if message['role'] == 'system' %}
+        <|start|><|system|><|message|>{{ message['content'] }}<|end|>
+    {% elif message['role'] == 'developer' %}
+        <|start|><|developer|><|message|>{{ message['content'] }}<|end|>
+    {% elif message['role'] == 'user' %}
+        <|start|><|user|><|message|>{{ message['content'] }}<|end|>
+    {% elif message['role'] == 'assistant' %}
+        <|start|><|assistant|><|channel|>{{ message['channel'] }}<|message|>{{ message['content'] }}<|end|>
+    {% elif message['role'] == 'tool' %}
+        <|start|><|tool|><|message|>{{ message['content'] }}<|end|>
+    {% endif %}
+{% endfor %}
+```
+
+Special tokens added: `<|start|>`, `<|end|>`, `<|call|>`, `<|system|>`, `<|developer|>`, `<|user|>`, `<|assistant|>`, `<|tool|>`, `<|channel|>`, `<|message|>`.
+
+### Model Card
+
+- Intended use: Research and experimentation with hybrid attention mechanisms and Harmony chat formatting for small LMs; text generation and chat.
+- Limitations: Not pretrained; behavior depends on training. Sliding window layers limit per-layer receptive field; ensure `layer_types` match use cases.
+- Biases: As with all language models, potential to reproduce biases present in training data. Evaluate and mitigate before deployment.
+

--- a/src/transformers/models/blueberry/__init__.py
+++ b/src/transformers/models/blueberry/__init__.py
@@ -1,0 +1,28 @@
+# coding=utf-8
+# Copyright 2025 Dustin Loring
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .configuration_blueberry import BlueberryConfig
+from .modeling_blueberry import BlueberryForCausalLM, BlueberryModel, BlueberryPreTrainedModel
+from .tokenization_blueberry import BlueberryTokenizer, BlueberryTokenizerFast
+
+__all__ = [
+    "BlueberryConfig",
+    "BlueberryPreTrainedModel",
+    "BlueberryModel",
+    "BlueberryForCausalLM",
+    "BlueberryTokenizer",
+    "BlueberryTokenizerFast",
+]
+

--- a/src/transformers/models/blueberry/configuration_blueberry.py
+++ b/src/transformers/models/blueberry/configuration_blueberry.py
@@ -1,0 +1,126 @@
+# coding=utf-8
+# Copyright 2025 Dustin Loring
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ...configuration_utils import PretrainedConfig
+
+
+class BlueberryConfig(PretrainedConfig):
+    model_type = "blueberry"
+
+    def __init__(
+        self,
+        n_positions=1024,
+        n_embd=768,
+        n_layer=12,
+        n_head=12,
+        hidden_act="silu",
+        resid_pdrop=0.1,
+        embd_pdrop=0.1,
+        layer_norm_epsilon=1e-05,
+        initializer_range=0.02,
+        summary_type="cls_index",
+        summary_use_proj=True,
+        summary_activation=None,
+        summary_proj_to_labels=True,
+        summary_first_dropout=0.1,
+        scale_attn_weights=True,
+        scale_attn_by_inverse_layer_idx=False,
+        reorder_and_upcast_attn=False,
+        attention_bias=True,
+        attention_dropout=0.0,
+        rms_norm_eps=1e-05,
+        rope_scaling=None,
+        rope_theta=150000,
+        sliding_window=128,
+        tie_word_embeddings=False,
+        use_cache=True,
+        layer_types=None,
+        vocab_size=100000,
+        **kwargs,
+    ):
+        if rope_scaling is None:
+            rope_scaling = {
+                "beta_fast": 32.0,
+                "beta_slow": 1.0,
+                "factor": 32.0,
+                "original_max_position_embeddings": 4096,
+                "rope_type": "yarn",
+                "truncate": False,
+            }
+
+        if layer_types is None:
+            layer_types = [
+                "sliding_attention",
+                "full_attention",
+                "sliding_attention",
+                "full_attention",
+                "sliding_attention",
+                "full_attention",
+                "sliding_attention",
+                "full_attention",
+                "sliding_attention",
+                "full_attention",
+                "sliding_attention",
+                "full_attention",
+                "sliding_attention",
+                "full_attention",
+                "sliding_attention",
+                "full_attention",
+                "sliding_attention",
+                "full_attention",
+                "sliding_attention",
+                "full_attention",
+                "sliding_attention",
+                "full_attention",
+                "sliding_attention",
+                "full_attention",
+            ]
+
+        super().__init__(tie_word_embeddings=tie_word_embeddings, **kwargs)
+
+        # Map legacy-style names to HF standard names too
+        self.n_positions = n_positions
+        self.n_embd = n_embd
+        self.n_layer = n_layer
+        self.n_head = n_head
+        self.hidden_act = hidden_act
+        self.resid_pdrop = resid_pdrop
+        self.embd_pdrop = embd_pdrop
+        self.layer_norm_epsilon = layer_norm_epsilon
+        self.initializer_range = initializer_range
+        self.summary_type = summary_type
+        self.summary_use_proj = summary_use_proj
+        self.summary_activation = summary_activation
+        self.summary_proj_to_labels = summary_proj_to_labels
+        self.summary_first_dropout = summary_first_dropout
+        self.scale_attn_weights = scale_attn_weights
+        self.scale_attn_by_inverse_layer_idx = scale_attn_by_inverse_layer_idx
+        self.reorder_and_upcast_attn = reorder_and_upcast_attn
+        self.attention_bias = attention_bias
+        self.attention_dropout = attention_dropout
+        self.rms_norm_eps = rms_norm_eps
+        self.rope_scaling = rope_scaling
+        self.rope_theta = rope_theta
+        self.sliding_window = sliding_window
+        self.use_cache = use_cache
+        self.layer_types = layer_types
+        self.vocab_size = vocab_size
+
+        # Align with common HF names used by internals
+        self.hidden_size = n_embd
+        self.num_hidden_layers = n_layer
+        self.num_attention_heads = n_head
+        self.max_position_embeddings = n_positions
+

--- a/src/transformers/models/blueberry/modeling_blueberry.py
+++ b/src/transformers/models/blueberry/modeling_blueberry.py
@@ -1,0 +1,475 @@
+# coding=utf-8
+# Copyright 2025 Dustin Loring
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable, Optional, Tuple
+
+import torch
+from torch import nn
+
+from ...activations import ACT2FN
+from ...cache_utils import Cache, DynamicCache
+from ...generation import GenerationMixin
+from ...masking_utils import create_causal_mask, create_sliding_window_causal_mask
+from ...modeling_layers import GradientCheckpointingLayer
+from ...modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
+from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
+from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
+from ...processing_utils import Unpack
+from ...utils import TransformersKwargs, auto_docstring
+from ...utils.generic import check_model_inputs
+from .configuration_blueberry import BlueberryConfig
+
+
+def rotate_half(x: torch.Tensor) -> torch.Tensor:
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb(
+    q: torch.Tensor, k: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, unsqueeze_dim: int = 1
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+def repeat_kv(hidden_states: torch.Tensor, num_key_value_groups: int) -> torch.Tensor:
+    batch, num_key_value_heads, seq_len, head_dim = hidden_states.shape
+    if num_key_value_groups == 1:
+        return hidden_states
+    hidden_states = hidden_states[:, :, None, :, :].expand(
+        batch, num_key_value_heads, num_key_value_groups, seq_len, head_dim
+    )
+    return hidden_states.reshape(batch, num_key_value_heads * num_key_value_groups, seq_len, head_dim)
+
+
+def eager_attention_forward(
+    module: nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: Optional[torch.Tensor],
+    scaling: float,
+    dropout: float = 0.0,
+    **kwargs: Unpack[TransformersKwargs],
+):
+    key_states = repeat_kv(key, module.num_key_value_groups)
+    value_states = repeat_kv(value, module.num_key_value_groups)
+
+    attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling
+    if attention_mask is not None:
+        causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
+        attn_weights = attn_weights + causal_mask
+
+    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    attn_weights = nn.functional.dropout(attn_weights, p=dropout, training=module.training)
+    attn_output = torch.matmul(attn_weights, value_states)
+    attn_output = attn_output.transpose(1, 2).contiguous()
+    return attn_output, attn_weights
+
+
+class BlueberryAttention(nn.Module):
+    def __init__(self, config: BlueberryConfig, layer_idx: int):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        self.num_key_value_heads = getattr(config, "num_key_value_heads", config.num_attention_heads)
+        self.num_key_value_groups = config.num_attention_heads // self.num_key_value_heads
+        self.scaling = self.head_dim**-0.5
+        self.attention_dropout = config.attention_dropout
+        self.is_causal = True
+
+        self.q_proj = nn.Linear(config.hidden_size, config.num_attention_heads * self.head_dim, bias=config.attention_bias)
+        self.k_proj = nn.Linear(config.hidden_size, self.num_key_value_heads * self.head_dim, bias=config.attention_bias)
+        self.v_proj = nn.Linear(config.hidden_size, self.num_key_value_heads * self.head_dim, bias=config.attention_bias)
+        self.o_proj = nn.Linear(config.num_attention_heads * self.head_dim, config.hidden_size, bias=config.attention_bias)
+
+        # sliding window when requested
+        self.sliding_window = config.sliding_window if config.layer_types[layer_idx] == "sliding_attention" else None
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        attention_mask: Optional[torch.Tensor],
+        past_key_values: Optional[Cache] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        input_shape = hidden_states.shape[:-1]
+        hidden_shape = (*input_shape, -1, self.head_dim)
+
+        query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+        key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+        value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+
+        cos, sin = position_embeddings
+        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
+
+        if past_key_values is not None:
+            cache_kwargs = {"cache_position": cache_position}
+            key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx, cache_kwargs)
+
+        attention_interface: Callable = eager_attention_forward
+        if self.config._attn_implementation != "eager":
+            attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+
+        attn_output, attn_weights = attention_interface(
+            self,
+            query_states,
+            key_states,
+            value_states,
+            attention_mask,
+            dropout=0.0 if not self.training else self.attention_dropout,
+            scaling=self.scaling,
+            sliding_window=self.sliding_window,
+            **kwargs,
+        )
+
+        attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+        attn_output = self.o_proj(attn_output)
+        return attn_output, attn_weights
+
+
+class BlueberryNoPEAttention(nn.Module):
+    def __init__(self, config: BlueberryConfig, layer_idx: int):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        self.num_key_value_heads = getattr(config, "num_key_value_heads", config.num_attention_heads)
+        self.num_key_value_groups = config.num_attention_heads // self.num_key_value_heads
+        self.scaling = self.head_dim**-0.5
+        self.attention_dropout = config.attention_dropout
+        self.is_causal = True
+
+        self.q_proj = nn.Linear(config.hidden_size, config.num_attention_heads * self.head_dim, bias=config.attention_bias)
+        self.k_proj = nn.Linear(config.hidden_size, self.num_key_value_heads * self.head_dim, bias=config.attention_bias)
+        self.v_proj = nn.Linear(config.hidden_size, self.num_key_value_heads * self.head_dim, bias=config.attention_bias)
+        self.o_proj = nn.Linear(config.num_attention_heads * self.head_dim, config.hidden_size, bias=config.attention_bias)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        attention_mask: Optional[torch.Tensor],
+        past_key_values: Optional[Cache] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        input_shape = hidden_states.shape[:-1]
+        hidden_shape = (*input_shape, -1, self.head_dim)
+
+        query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+        key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+        value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+
+        # No RoPE application here (NoPE)
+        if past_key_values is not None:
+            cache_kwargs = {"cache_position": cache_position}
+            key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx, cache_kwargs)
+
+        attention_interface: Callable = eager_attention_forward
+        if self.config._attn_implementation != "eager":
+            attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+
+        attn_output, attn_weights = attention_interface(
+            self,
+            query_states,
+            key_states,
+            value_states,
+            attention_mask,
+            dropout=0.0 if not self.training else self.attention_dropout,
+            scaling=self.scaling,
+            **kwargs,
+        )
+
+        attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+        attn_output = self.o_proj(attn_output)
+        return attn_output, attn_weights
+
+
+class BlueberryRMSNorm(nn.Module):
+    def __init__(self, hidden_size: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+    def extra_repr(self) -> str:
+        return f"{tuple(self.weight.shape)}, eps={self.variance_epsilon}"
+
+
+class BlueberryMLP(nn.Module):
+    def __init__(self, config: BlueberryConfig):
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = getattr(config, "intermediate_size", 4 * config.hidden_size)
+        self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=True)
+        self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=True)
+        self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=True)
+        self.act_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
+
+
+class BlueberryDecoderLayer(GradientCheckpointingLayer):
+    def __init__(self, config: BlueberryConfig, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        attn_type = config.layer_types[layer_idx]
+        if attn_type == "sliding_attention":
+            self.self_attn = BlueberryAttention(config=config, layer_idx=layer_idx)
+        else:
+            self.self_attn = BlueberryNoPEAttention(config=config, layer_idx=layer_idx)
+        self.mlp = BlueberryMLP(config)
+        self.input_layernorm = BlueberryRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = BlueberryRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.attention_type = attn_type
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        use_cache: Optional[bool] = False,
+        cache_position: Optional[torch.LongTensor] = None,
+        position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states, _ = self.self_attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            cache_position=cache_position,
+            position_embeddings=position_embeddings,
+            **kwargs,
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+class BlueberryRotaryEmbedding(nn.Module):
+    inv_freq: torch.Tensor
+
+    def __init__(self, config: BlueberryConfig, device=None):
+        super().__init__()
+        if hasattr(config, "rope_scaling") and isinstance(config.rope_scaling, dict):
+            self.rope_type = config.rope_scaling.get("rope_type", config.rope_scaling.get("type", "default"))
+        else:
+            self.rope_type = "default"
+        self.max_seq_len_cached = config.max_position_embeddings
+        self.original_max_seq_len = config.max_position_embeddings
+
+        self.config = config
+        self.rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+
+        inv_freq, self.attention_scaling = self.rope_init_fn(self.config, device)
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.original_inv_freq = self.inv_freq
+
+    @torch.no_grad()
+    @dynamic_rope_update
+    def forward(self, x: torch.Tensor, position_ids: torch.LongTensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        position_ids_expanded = position_ids[:, None, :].float()
+
+        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        with torch.autocast(device_type=device_type, enabled=False):
+            freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+            emb = torch.cat((freqs, freqs), dim=-1)
+            cos = emb.cos() * self.attention_scaling
+            sin = emb.sin() * self.attention_scaling
+
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+
+class BlueberryPreTrainedModel(PreTrainedModel):
+    config_class = BlueberryConfig
+    base_model_prefix = "model"
+    supports_gradient_checkpointing = True
+    _no_split_modules = ["BlueberryDecoderLayer"]
+    _skip_keys_device_placement = ["past_key_values"]
+    _supports_flash_attn = True
+    _supports_sdpa = True
+    _supports_flex_attn = True
+
+    _can_compile_fullgraph = True
+    _supports_attention_backend = True
+
+    _can_record_outputs = {
+        "hidden_states": BlueberryDecoderLayer,
+        "attentions": BlueberryAttention,
+    }
+
+
+class BlueberryModel(BlueberryPreTrainedModel):
+    def __init__(self, config: BlueberryConfig):
+        super().__init__(config)
+        self.padding_idx = getattr(config, "pad_token_id", None)
+        self.vocab_size = config.vocab_size
+
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        self.layers = nn.ModuleList([BlueberryDecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)])
+        self.norm = BlueberryRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rotary_emb = BlueberryRotaryEmbedding(config=config)
+        self.gradient_checkpointing = False
+        self.has_sliding_layers = "sliding_attention" in self.config.layer_types
+
+        self.post_init()
+
+    @check_model_inputs
+    @auto_docstring
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        use_cache: Optional[bool] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> BaseModelOutputWithPast:
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        if use_cache and past_key_values is None:
+            past_key_values = DynamicCache(config=self.config)
+
+        if cache_position is None:
+            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+            cache_position = torch.arange(past_seen_tokens, past_seen_tokens + inputs_embeds.shape[1], device=inputs_embeds.device)
+
+        if position_ids is None:
+            position_ids = cache_position.unsqueeze(0)
+
+        if not isinstance(causal_mask_mapping := attention_mask, dict):
+            mask_kwargs = {
+                "config": self.config,
+                "input_embeds": inputs_embeds,
+                "attention_mask": attention_mask,
+                "cache_position": cache_position,
+                "past_key_values": past_key_values,
+                "position_ids": position_ids,
+            }
+            causal_mask_mapping = {
+                "full_attention": create_causal_mask(**mask_kwargs),
+            }
+            if self.has_sliding_layers:
+                causal_mask_mapping["sliding_attention"] = create_sliding_window_causal_mask(**mask_kwargs)
+
+        hidden_states = inputs_embeds
+        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+
+        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+            hidden_states = decoder_layer(
+                hidden_states,
+                attention_mask=causal_mask_mapping[decoder_layer.attention_type],
+                position_ids=position_ids,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                cache_position=cache_position,
+                position_embeddings=position_embeddings,
+                **kwargs,
+            )
+
+        hidden_states = self.norm(hidden_states)
+        return BaseModelOutputWithPast(last_hidden_state=hidden_states, past_key_values=past_key_values if use_cache else None)
+
+
+class BlueberryForCausalLM(BlueberryPreTrainedModel, GenerationMixin):
+    _tied_weights_keys = ["lm_head.weight"]
+
+    def __init__(self, config: BlueberryConfig):
+        super().__init__(config)
+        self.model = BlueberryModel(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+        self.post_init()
+
+    @auto_docstring
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        logits_to_keep: int = 0,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> CausalLMOutputWithPast:
+        outputs: BaseModelOutputWithPast = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            **kwargs,
+        )
+
+        hidden_states = outputs.last_hidden_state
+        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) and logits_to_keep > 0 else slice(None)
+        logits = self.lm_head(hidden_states[:, slice_indices, :])
+
+        loss = None
+        if labels is not None:
+            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs)
+
+        return CausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )
+
+
+__all__ = [
+    "BlueberryPreTrainedModel",
+    "BlueberryModel",
+    "BlueberryForCausalLM",
+]
+

--- a/src/transformers/models/blueberry/tokenization_blueberry.py
+++ b/src/transformers/models/blueberry/tokenization_blueberry.py
@@ -1,0 +1,173 @@
+# coding=utf-8
+# Copyright 2025 Dustin Loring
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+from ...tokenization_utils import PreTrainedTokenizer
+from ...tokenization_utils_base import BatchEncoding
+from ...tokenization_utils_fast import PreTrainedTokenizerFast
+from ...utils import logging
+from ..gpt2.tokenization_gpt2 import GPT2Tokenizer
+
+
+logger = logging.get_logger(__name__)
+
+
+VOCAB_FILES_NAMES = {
+    "vocab_file": "vocab.json",
+    "merges_file": "merges.txt",
+    "tokenizer_file": "tokenizer.json",
+}
+
+
+HARMONY_SPECIAL_TOKENS = [
+    "<|start|>",
+    "<|end|>",
+    "<|call|>",
+    "<|system|>",
+    "<|developer|>",
+    "<|user|>",
+    "<|assistant|>",
+    "<|tool|>",
+    "<|channel|>",
+    "<|message|>",
+]
+
+
+HARMONY_CHAT_TEMPLATE = (
+    "{% for message in messages %}"
+    "{% if message['role'] == 'system' %}"
+    "<|start|><|system|><|message|>{{ message['content'] }}<|end|>"
+    "{% elif message['role'] == 'developer' %}"
+    "<|start|><|developer|><|message|>{{ message['content'] }}<|end|>"
+    "{% elif message['role'] == 'user' %}"
+    "<|start|><|user|><|message|>{{ message['content'] }}<|end|>"
+    "{% elif message['role'] == 'assistant' %}"
+    "<|start|><|assistant|><|channel|>{{ message['channel'] }}<|message|>{{ message['content'] }}<|end|>"
+    "{% elif message['role'] == 'tool' %}"
+    "<|start|><|tool|><|message|>{{ message['content'] }}<|end|>"
+    "{% endif %}"
+    "{% endfor %}"
+)
+
+
+class BlueberryTokenizer(GPT2Tokenizer):
+    vocab_files_names = {k: v for k, v in VOCAB_FILES_NAMES.items() if k != "tokenizer_file"}
+    model_input_names = ["input_ids", "attention_mask"]
+
+    def __init__(
+        self,
+        vocab_file,
+        merges_file,
+        errors="replace",
+        unk_token="<|endoftext|>",
+        bos_token="<|endoftext|>",
+        eos_token="<|endoftext|>",
+        pad_token=None,
+        add_prefix_space=False,
+        add_bos_token=False,
+        **kwargs,
+    ):
+        super().__init__(
+            vocab_file=vocab_file,
+            merges_file=merges_file,
+            errors=errors,
+            unk_token=unk_token,
+            bos_token=bos_token,
+            eos_token=eos_token,
+            pad_token=pad_token,
+            add_prefix_space=add_prefix_space,
+            add_bos_token=add_bos_token,
+            **kwargs,
+        )
+
+        # Register Harmony special tokens if not already present
+        to_add = []
+        for tok in HARMONY_SPECIAL_TOKENS:
+            if tok not in self.get_vocab():
+                to_add.append(tok)
+        if to_add:
+            self.add_tokens(to_add, special_tokens=True)
+
+        # Set chat template
+        try:
+            self.chat_template = HARMONY_CHAT_TEMPLATE
+        except Exception as e:
+            logger.warning(f"Failed to set chat_template for BlueberryTokenizer: {e}")
+
+
+class BlueberryTokenizerFast(PreTrainedTokenizerFast):
+    vocab_files_names = VOCAB_FILES_NAMES
+    model_input_names = ["input_ids", "attention_mask"]
+    slow_tokenizer_class = BlueberryTokenizer
+
+    def __init__(
+        self,
+        vocab_file: Optional[str] = None,
+        merges_file: Optional[str] = None,
+        tokenizer_file: Optional[str] = None,
+        unk_token: str = "<|endoftext|>",
+        bos_token: str = "<|endoftext|>",
+        eos_token: str = "<|endoftext|>",
+        add_prefix_space: bool = False,
+        **kwargs,
+    ):
+        super().__init__(
+            vocab_file=vocab_file,
+            merges_file=merges_file,
+            tokenizer_file=tokenizer_file,
+            unk_token=unk_token,
+            bos_token=bos_token,
+            eos_token=eos_token,
+            add_prefix_space=add_prefix_space,
+            **kwargs,
+        )
+
+        # Ensure Harmony tokens exist; if a tokenizer.json is loaded these should exist already, otherwise add.
+        try:
+            added = 0
+            for tok in HARMONY_SPECIAL_TOKENS:
+                if self.convert_tokens_to_ids(tok) == self.unk_token_id:
+                    self.add_tokens([tok], special_tokens=True)
+                    added += 1
+            if added:
+                logger.info(f"Added {added} Harmony special tokens to BlueberryTokenizerFast")
+        except Exception:
+            pass
+
+        try:
+            self.chat_template = HARMONY_CHAT_TEMPLATE
+        except Exception as e:
+            logger.warning(f"Failed to set chat_template for BlueberryTokenizerFast: {e}")
+
+    def _batch_encode_plus(self, *args, **kwargs) -> BatchEncoding:
+        is_split_into_words = kwargs.get("is_split_into_words", False)
+        assert self.add_prefix_space or not is_split_into_words, (
+            f"You need to instantiate {self.__class__.__name__} with add_prefix_space=True "
+            "to use it with pretokenized inputs."
+        )
+        return super()._batch_encode_plus(*args, **kwargs)
+
+    def _encode_plus(self, *args, **kwargs) -> BatchEncoding:
+        is_split_into_words = kwargs.get("is_split_into_words", False)
+        assert self.add_prefix_space or not is_split_into_words, (
+            f"You need to instantiate {self.__class__.__name__} with add_prefix_space=True "
+            "to use it with pretokenized inputs."
+        )
+        return super()._encode_plus(*args, **kwargs)
+
+
+__all__ = ["BlueberryTokenizer", "BlueberryTokenizerFast"]
+

--- a/tests/models/blueberry/test_modeling_blueberry.py
+++ b/tests/models/blueberry/test_modeling_blueberry.py
@@ -1,0 +1,43 @@
+import unittest
+
+import torch
+
+from transformers import BlueberryConfig
+from transformers.models.blueberry.modeling_blueberry import BlueberryForCausalLM, BlueberryModel
+
+
+class BlueberryModelTest(unittest.TestCase):
+    def test_forward_output_shape(self):
+        config = BlueberryConfig(n_positions=64, n_embd=64, n_layer=2, n_head=4, vocab_size=1000)
+        model = BlueberryModel(config)
+        input_ids = torch.randint(0, config.vocab_size, (2, 8))
+        outputs = model(input_ids=input_ids)
+        self.assertEqual(outputs.last_hidden_state.shape, (2, 8, config.hidden_size))
+
+    def test_causallm_head(self):
+        config = BlueberryConfig(n_positions=64, n_embd=64, n_layer=2, n_head=4, vocab_size=1000)
+        model = BlueberryForCausalLM(config)
+        input_ids = torch.randint(0, config.vocab_size, (1, 7))
+        outputs = model(input_ids=input_ids)
+        self.assertEqual(outputs.logits.shape[-1], config.vocab_size)
+
+    def test_layer_types_switching(self):
+        # sliding and full attention layers alternate by default; ensure no error
+        config = BlueberryConfig(n_positions=64, n_embd=64, n_layer=4, n_head=4, vocab_size=1000)
+        model = BlueberryModel(config)
+        input_ids = torch.randint(0, config.vocab_size, (1, 12))
+        _ = model(input_ids=input_ids)
+
+
+class BlueberryModelIntegrationTest(unittest.TestCase):
+    def test_from_pretrained_config(self):
+        config = BlueberryConfig()
+        model = BlueberryForCausalLM(config)
+        input_ids = torch.randint(0, config.vocab_size, (1, 5))
+        outputs = model(input_ids=input_ids)
+        self.assertIsNotNone(outputs.logits)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/models/blueberry/test_tokenization_blueberry.py
+++ b/tests/models/blueberry/test_tokenization_blueberry.py
@@ -1,0 +1,67 @@
+import os
+import tempfile
+import unittest
+
+from transformers.models.blueberry.tokenization_blueberry import (
+    BlueberryTokenizer,
+    BlueberryTokenizerFast,
+)
+
+
+class BlueberryTokenizerTest(unittest.TestCase):
+    def setUp(self):
+        # Minimal fake vocab/merges for GPT2-style tokenizers
+        self.tmpdir = tempfile.TemporaryDirectory()
+        vocab_path = os.path.join(self.tmpdir.name, "vocab.json")
+        merges_path = os.path.join(self.tmpdir.name, "merges.txt")
+        with open(vocab_path, "w", encoding="utf-8") as vf:
+            vf.write("{\n  \"<|endoftext|>\":0, \"hello\":1, \"world\":2\n}\n")
+        with open(merges_path, "w", encoding="utf-8") as mf:
+            mf.write("#version: 0.2\n\nh e\nl l\nlo </w>\n")
+        self.vocab_file = vocab_path
+        self.merges_file = merges_path
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_encode_decode_roundtrip(self):
+        tok = BlueberryTokenizer(vocab_file=self.vocab_file, merges_file=self.merges_file)
+        text = "hello world"
+        ids = tok(text)["input_ids"]
+        decoded = tok.decode(ids)
+        self.assertIsInstance(ids, list)
+        self.assertIsInstance(decoded, str)
+
+    def test_harmony_chat_template_presence(self):
+        tok = BlueberryTokenizer(vocab_file=self.vocab_file, merges_file=self.merges_file)
+        self.assertTrue(hasattr(tok, "chat_template"))
+        template = tok.chat_template
+        self.assertIn("<|start|>", template)
+        self.assertIn("<|assistant|>", template)
+
+
+class BlueberryTokenizerFastTest(unittest.TestCase):
+    def setUp(self):
+        # Use slow to build then convert to fast via save/load tokenizer.json is out of scope for unit
+        self.tmpdir = tempfile.TemporaryDirectory()
+        vocab_path = os.path.join(self.tmpdir.name, "vocab.json")
+        merges_path = os.path.join(self.tmpdir.name, "merges.txt")
+        with open(vocab_path, "w", encoding="utf-8") as vf:
+            vf.write("{\n  \"<|endoftext|>\":0, \"hello\":1, \"world\":2\n}\n")
+        with open(merges_path, "w", encoding="utf-8") as mf:
+            mf.write("#version: 0.2\n\nh e\nl l\nlo </w>\n")
+        self.vocab_file = vocab_path
+        self.merges_file = merges_path
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_fast_init_and_chat_template(self):
+        tok = BlueberryTokenizerFast(vocab_file=self.vocab_file, merges_file=self.merges_file)
+        self.assertTrue(hasattr(tok, "chat_template"))
+        self.assertIn("<|start|>", tok.chat_template)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
# What does this PR do?

This PR introduces the new "Blueberry" model to the `transformers` library. Blueberry is a small, decoder-only language model featuring a novel hybrid attention mechanism that alternates between RoPE with YaRN scaling (sliding window) and NoPE (full attention) layers. It also includes a custom GPT-2-like tokenizer with a 100K vocabulary and implements the Harmony Chat Format via a Jinja2 template.

The PR adds:
*   `src/transformers/models/blueberry/`: Model configuration, core modeling, and tokenizer implementations.
*   `tests/models/blueberry/`: Unit tests for the model's architecture and tokenizer functionality, including the chat template.
*   `docs/source/en/model_doc/blueberry.md`: Comprehensive documentation for the model.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. (This was a direct task, assuming approval)
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@ArthurZucker (text models, tokenizers)
@Rocketknight1 (chat templates)

---
<a href="https://cursor.com/background-agent?bcId=bc-bba70a0d-74ff-413e-b588-bb118ee5666a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bba70a0d-74ff-413e-b588-bb118ee5666a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

